### PR TITLE
support ios 10

### DIFF
--- a/lib/project/reminders.rb
+++ b/lib/project/reminders.rb
@@ -3,7 +3,8 @@ module Takeoff
 
     class << self
       def setup
-        if Device.ios_version >= "8.0"
+        version_components = Device.ios_version.split '.'
+        if version_components[0].to_i >= 8
           types = UIUserNotificationTypeSound | UIUserNotificationTypeBadge | UIUserNotificationTypeAlert
           notificationSettings = UIUserNotificationSettings.settingsForTypes(types, categories:nil)
           UIApplication.sharedApplication.registerUserNotificationSettings(notificationSettings)


### PR DESCRIPTION
This PR fixes the ios_version check to be aware of iOS versions starting with 1, aka 10.x
(nil)? Device.ios_version
=> "10.3.1"
(main)> Device.ios_version >= "8.0"
=> false
Err, not really. This PR breaks the version string in to its component parts and compares the major version number as integers.
